### PR TITLE
Remove no longer required workaround in boost 1.73 and later

### DIFF
--- a/src/planet-dump.cpp
+++ b/src/planet-dump.cpp
@@ -126,8 +126,10 @@ int main(int argc, char *argv[]) {
     po::variables_map options;
     get_options(argc, argv, options);
 
+#if BOOST_VERSION < 107300
     // workaround for https://svn.boost.org/trac/boost/ticket/5638
     boost::gregorian::greg_month::get_month_map_ptr();
+#endif
 
     // extract data from the dump file for the "sorted" data tables, like nodes,
     // ways, relations, changesets and their associated tags, etc...


### PR DESCRIPTION
This workaround no longer compiles in boost 1.73 and later as `get_month_map_ptr` was removed in https://github.com/boostorg/date_time/commit/cb3bd50b90a3b1e142d0eaf02e73f410462e6ee7.

I believe the new code should be thread safe for C++11 and later.